### PR TITLE
Changed Login to not use its own UIWindow and Removed Unused OK_FBSessionStateChangedNotification

### DIFF
--- a/OpenKit/OKLoginView.m
+++ b/OpenKit/OKLoginView.m
@@ -15,7 +15,6 @@
     OKLoginViewCompletionHandler loginDialogCompletionHandler;
 }
 
-@property (nonatomic, strong) UIWindow *baseWindow;
 @property (nonatomic, strong) UIView *loginView;
 @property (nonatomic, strong) OKBaseLoginViewController *baseViewController;
 
@@ -23,31 +22,23 @@
 
 @implementation OKLoginView
 
-@synthesize loginView, baseWindow, baseViewController;
+@synthesize loginView, baseViewController;
 
 -(id)init
 {
     self = [super init];
     if(self)
     {
-        //Create the base window
-        baseWindow = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-        baseWindow.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
-        baseWindow.opaque = NO;
-        
         baseViewController = [[OKBaseLoginViewController alloc] init];
-        
-        [baseWindow setRootViewController:baseViewController];
-        //[baseWindow setWindowLevel:UIWindowLevelAlert];
     }
     return self;
 }
 
 -(void)show
 {
-    //Show the base window on the main thread
+    //Show the base view controller on the main thread
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self.baseWindow makeKeyAndVisible];
+        [[[UIApplication sharedApplication] keyWindow] addSubview:baseViewController.view];
     });
     
     [baseViewController setDelegate:self];
@@ -62,9 +53,9 @@
 
 -(void)dismiss
 {
-    //Show the base window on the main thread
+    //Remove the base view controller on the main thread
     dispatch_async(dispatch_get_main_queue(), ^{
-        [baseWindow removeFromSuperview];
+        [baseViewController.view removeFromSuperview];
     });
     
     [baseViewController setDelegate:nil];

--- a/SampleApp/OKAppDelegate.h
+++ b/SampleApp/OKAppDelegate.h
@@ -11,6 +11,7 @@
 @class OKViewController;
 
 
+
 @interface OKAppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;

--- a/SampleApp/OKAppDelegate.h
+++ b/SampleApp/OKAppDelegate.h
@@ -8,7 +8,6 @@
 
 #import <UIKit/UIKit.h>
 
-extern NSString *const OK_FBSessionStateChangedNotification;
 @class OKViewController;
 
 

--- a/SampleApp/OKAppDelegate.m
+++ b/SampleApp/OKAppDelegate.m
@@ -13,8 +13,6 @@
 //#import "OKCloud.h"
 //#import <objc/runtime.h>
 
-NSString *const OK_FBSessionStateChangedNotification = @"OK_FBSessionStateChangedNotification";
-
 
 @implementation OKAppDelegate
 


### PR DESCRIPTION
When integrating into a sample iOS Cocos2d-x app, the game's window/view did not receive touch events after the OpenKit login sequence of views and events. One of the commits here fixes this by modifying the OKLogin to not create its own window but merely add the login views to the pre-existing UIWindow.

Is there any particular reason why OKLogin was originally set up to use a separate UIWindow that would make this modification inappropriate?

Also, this fork has removed two lines believed to be unnecessary in the sample app (lines that declare the constant NSString OK_FBSessionStateChangedNotification).

Is it correct that this code no longer serves any purpose?
